### PR TITLE
Fix variable name in coach POST validation

### DIFF
--- a/api/routes/coachRouter.js
+++ b/api/routes/coachRouter.js
@@ -72,11 +72,11 @@ router.post('/', function(req, res) {
 	const postParams = ['email', 'first_name', 'last_name', 'password'];
 	for (var i = 0; i < postParams.length; i++) {
 		const confirmPostParams = postParams[i];
-		if(!(confirmPostParams in req.body)) {
-			const errorMessage = `Sorry your missing ${confirmedParams} please try again`;
-			console.error(errorMessage);
-			return res.status(400).send(errorMessage)
-		}
+                if(!(confirmPostParams in req.body)) {
+                        const errorMessage = `Sorry your missing ${confirmPostParams} please try again`;
+                        console.error(errorMessage);
+                        return res.status(400).send(errorMessage)
+                }
 	}
 	Coach.hashPassword(req.body.password)
 		.then(function(hashedPassword){


### PR DESCRIPTION
## Summary
- use `confirmPostParams` consistently when validating coach POST requests

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894099d67f083289382466e3544ec80