### PR TITLE
Return success status for session logout

### DIFF
--- a/api/routes/coachRouter.js
+++ b/api/routes/coachRouter.js
@@ -134,8 +134,8 @@ router.put('/:id', function(req, res) {
  * Delete the current active session
  */
 router.delete('/', function(req, res) {
-	req.session.destroy(); //After this session is destroyes reauthenticate is needed
-	res.status(400).send();
+        req.session.destroy(); //After this session is destroyes reauthenticate is needed
+        res.sendStatus(204);
 })
 
 


### PR DESCRIPTION
## Summary
- Use HTTP 204 on coach logout, signaling successful session destruction

## Testing
- `npm test` *(fails: react-scripts: not found)*
- `npm install --no-audit --no-fund` *(fails: build error for bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_689409a4706883289a6429fcc2c1a5d2