### PR TITLE
Fix statRouter relations to use existing player associations

### DIFF
--- a/api/routes/statRouter.js
+++ b/api/routes/statRouter.js
@@ -13,17 +13,17 @@ router.use(jsonParser);
 router.get('/', function(req, res) {
   Stat
   .fetchAll()
-  .then(function(stats) {
-    res.json(stats);
+  .then(function(statCatalogs) {
+    res.json(statCatalogs);
   })
 })
 
 router.get('/:id', function(req, res) {
   Stat
   .where({id: req.params.id})
-  .fetch({withRelated: ['stats', 'stats.player']})
-  .then(function(stats) {
-    res.json(stats);
+  .fetch({withRelated: ['players', 'players.stats']})
+  .then(function(stat) {
+    res.json(stat);
   })
 })
 


### PR DESCRIPTION
## Summary
- correct stat details endpoint to fetch players and their stats

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: bcrypt build error with node v22.18.0)*

------
https://chatgpt.com/codex/tasks/task_e_689409b227ac8328898a51de73bdc076