### PR TITLE
Add dedicated session router

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,12 @@ id | description
 
 - [x] router.post('/')
 
-- [x] router.post('/login')
-
 - [x] router.put('/:id')
+
+#### `session`
+
+- [x] router.post('/login')
+- [x] router.delete('/')
 
 #### `player`
 

--- a/api/routes/coachRouter.js
+++ b/api/routes/coachRouter.js
@@ -44,32 +44,8 @@ router.get('/hashed/:password', function(req, res){
 
 })
 
-router.post('/login', function(req, res){
-	let coachData;
-	console.log(req.body);
-	Coach
-		.where({
-			email: req.body.email
-		})
-		.fetch()
-		.then(function(coach) {
-			coachData = coach;
-			console.log('password ====>', req.body.pwd);
-			return Coach.validatePassword(coachData.get('password'), req.body.pwd);
-		}).then(function(validPassword){
-			if(validPassword){
-				console.log(validPassword);
-				req.session.coachId = coachData.id; // assign / tie the user id to the session
-				res.status(200).json(coachData);
-			} else {
-				console.error('Wrong password');
-				res.status(404).json('Wrong password');
-			}
-		});
-});
-
 router.post('/', function(req, res) {
-	const postParams = ['email', 'first_name', 'last_name', 'password'];
+        const postParams = ['email', 'first_name', 'last_name', 'password'];
 	for (var i = 0; i < postParams.length; i++) {
 		const confirmPostParams = postParams[i];
                 if(!(confirmPostParams in req.body)) {
@@ -128,16 +104,5 @@ router.put('/:id', function(req, res) {
 			return res.status(500).json(err)
 		})
 })
-
-/*
- * # Logout
- * Delete the current active session
- */
-router.delete('/', function(req, res) {
-        req.session.destroy(); //After this session is destroyes reauthenticate is needed
-        res.sendStatus(204);
-})
-
-
 
 module.exports = router;

--- a/api/routes/sessionRouter.js
+++ b/api/routes/sessionRouter.js
@@ -1,0 +1,49 @@
+"use strict";
+const app = require('express');
+const router = app.Router();
+
+const bodyParser = require('body-parser');
+const jsonParser = bodyParser.json();
+
+const Coach = require('../models/Coach');
+
+router.use(bodyParser.urlencoded({
+        extended: true
+}));
+router.use(jsonParser);
+
+/*
+ * Login and create a new session
+ */
+router.post('/login', function(req, res){
+        let coachData;
+        Coach
+                .where({
+                        email: req.body.email
+                })
+                .fetch()
+                .then(function(coach) {
+                        coachData = coach;
+                        return Coach.validatePassword(coachData.get('password'), req.body.pwd);
+                }).then(function(validPassword){
+                        if(validPassword){
+                                req.session.coachId = coachData.id;
+                                res.status(200).json(coachData);
+                        } else {
+                                res.status(404).json('Wrong password');
+                        }
+                })
+                .catch(function(err){
+                        res.status(500).json(err);
+                });
+});
+
+/*
+ * Logout and destroy the current session
+ */
+router.delete('/', function(req, res) {
+        req.session.destroy();
+        res.sendStatus(204);
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ const playerRouter = require('./api/routes/playerRouter');
 const coachRouter = require('./api/routes/coachRouter');
 const teamRouter = require('./api/routes/teamRouter');
 const statRouter = require('./api/routes/statRouter');
+const sessionRouter = require('./api/routes/sessionRouter');
 
 
 app.use(morgan('common'));
@@ -35,7 +36,7 @@ app.use('/players', playerRouter);
 app.use('/coaches', coachRouter);
 app.use('/teams', teamRouter);
 app.use('/stats', statRouter);
-app.use('/sessions', coachRouter);
+app.use('/sessions', sessionRouter);
 
 let server;
 

--- a/src/actions/loginAction.js
+++ b/src/actions/loginAction.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const url = 'http://localhost:8080/coaches/login';
+const url = 'http://localhost:8080/sessions/login';
 export const LOGIN_REQUEST = 'LOGIN_REQUEST';
 export const login = (email, pwd) => dispatch => {
 	dispatch({


### PR DESCRIPTION
## Summary
- move login/logout logic into a new session router and mount it under `/sessions`
- update login action to use session endpoint
- document session endpoints in the README

## Testing
- `npm install` *(fails: node-pre-gyp ERR! build error for bcrypt)*
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68941795a98c83289ea0fa35104181f2