### PR TITLE
Remove Travis deploy block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,2 @@
 language: node_js
 node_js: node
-deploy:
-  provider: heroku
-  api_key:
-    secure:
-  app: stark-garden-73877
-  on:
-    repo: iamromanh/highlander-react-redux
-    branch: master


### PR DESCRIPTION
## Summary
- remove incomplete Heroku deploy configuration from `.travis.yml`

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test -- --watchAll=false` (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_68941d2e4e848328933ca1fdc9a874f7