### PR TITLE
Use environment-based configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,13 +19,9 @@
 .env.development.local
 .env.test.local
 .env.production.local
-config.js
 .AppleDouble
 .LSOverride
 
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-#DB Credentials
-/knexfile.js

--- a/config.js
+++ b/config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  DATABASE_URL: process.env.DATABASE_URL || 'postgresql://localhost/highlander-react-redux',
+  CLIENT_ORIGIN: process.env.CLIENT_ORIGIN || 'http://localhost:3000',
+  SECRET: process.env.SECRET || 'super-secret'
+};

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,35 +1,32 @@
-module.exports = {
-	development: {
-		client: 'postgresql',
-		connection: {
-			database: 'highlander-react-redux',
-			user: 'iamromanh',
-			password: 'updatePWandGitIgnore',
-			charset: 'utf8'
-		},
-		migrations: {
-			directory: 'data/migrations'
-		},
-		seeds: {
-			directory: 'data/seeds'
-		},
-		debug: true,
-		useNullAsDefault: true,
-	},
+const { DATABASE_URL } = require('./config');
 
-	production: {
-		client: 'pg',
-		connection: process.env.HEROKU_POSTGRESQL_ONYX_URL,
-		pool: {
-			min: 2,
-			max: 10
-		},
-		migrations: {
-			directory: 'data/migrations',
-			tableName: 'knex_migrations'
-		},
-		seeds: {
-			directory: 'data/prod_seeds'
-		}
-	}
+module.exports = {
+        development: {
+                client: 'pg',
+                connection: DATABASE_URL,
+                migrations: {
+                        directory: 'data/migrations'
+                },
+                seeds: {
+                        directory: 'data/seeds'
+                },
+                debug: true,
+                useNullAsDefault: true,
+        },
+
+        production: {
+                client: 'pg',
+                connection: DATABASE_URL,
+                pool: {
+                        min: 2,
+                        max: 10
+                },
+                migrations: {
+                        directory: 'data/migrations',
+                        tableName: 'knex_migrations'
+                },
+                seeds: {
+                        directory: 'data/prod_seeds'
+                }
+        }
 };

--- a/server.js
+++ b/server.js
@@ -1,15 +1,14 @@
 const express = require('express');
 const morgan = require('morgan');
 const session = require('express-session');
-const config = require('./config');
 const bodyParser = require('body-parser');
 const cors = require('cors');
-const { CLIENT_ORIGIN } = require('./config');
+const { SECRET, CLIENT_ORIGIN } = require('./config');
 
 const app = express();
 
 const sess = {
-	secret: config.SECRET,
+        secret: SECRET,
 	name: 'SessionMgmt',
 	resave: false,
 	saveUninitialized: true,
@@ -30,7 +29,7 @@ app.use(morgan('common'));
 app.use(session(sess));
 app.use(bodyParser.json());
 app.use(express.static('public'));
-app.use(cors());
+app.use(cors({ origin: CLIENT_ORIGIN }));
 
 app.use('/players', playerRouter);
 app.use('/coaches', coachRouter);


### PR DESCRIPTION
## Summary
- add committed `config.js` exporting environment-based database URL, client origin, and session secret
- load session secret and CORS origin from config in `server.js`
- use shared config for Knex connections
- allow config files to be tracked in version control

## Testing
- `npm test` *(fails: sh: 1: react-scripts: not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68941d0e6a30832893c6c104ade2418d