### PR TITLE
Serve React build via Express

### DIFF
--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ app.use(morgan('common'));
 app.use(session(sess));
 app.use(bodyParser.json());
 app.use(express.static('public'));
+app.use(express.static('build'));
 app.use(cors());
 
 app.use('/players', playerRouter);


### PR DESCRIPTION
## Summary
- expose the compiled React app by serving the `build` directory with Express.

## Testing
- `npm run build` *(fails: react-scripts: not found)*
- `CI=true npm test` *(fails: react-scripts: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68941d14fbc88328a26f5f4bc5866bd9