### PR TITLE
Configure CORS origin via environment config

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const env = process.env.NODE_ENV || 'development';
+
+const configs = {
+  development: {
+    CLIENT_ORIGIN: 'http://localhost:3000',
+    SECRET: process.env.SECRET || 'default',
+  },
+  test: {
+    CLIENT_ORIGIN: 'http://localhost:3000',
+    SECRET: process.env.SECRET || 'default',
+  },
+  production: {
+    CLIENT_ORIGIN: process.env.CLIENT_ORIGIN,
+    SECRET: process.env.SECRET,
+  },
+};
+
+module.exports = configs[env];
+

--- a/server.js
+++ b/server.js
@@ -1,15 +1,14 @@
 const express = require('express');
 const morgan = require('morgan');
 const session = require('express-session');
-const config = require('./config');
+const { CLIENT_ORIGIN, SECRET } = require('./config');
 const bodyParser = require('body-parser');
 const cors = require('cors');
-const { CLIENT_ORIGIN } = require('./config');
 
 const app = express();
 
 const sess = {
-	secret: config.SECRET,
+        secret: SECRET,
 	name: 'SessionMgmt',
 	resave: false,
 	saveUninitialized: true,
@@ -30,7 +29,7 @@ app.use(morgan('common'));
 app.use(session(sess));
 app.use(bodyParser.json());
 app.use(express.static('public'));
-app.use(cors());
+app.use(cors({ origin: CLIENT_ORIGIN }));
 
 app.use('/players', playerRouter);
 app.use('/coaches', coachRouter);


### PR DESCRIPTION
## Summary
- configure CORS origin using CLIENT_ORIGIN from config
- add environment-specific config for client origin and session secret

## Testing
- `npm install` (fails: unable to resolve dependency tree)
- `npm install --legacy-peer-deps` (fails: 403 forbidden for bulma)
- `npm test -- --watchAll=false` (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_68941d1958888328b4c81247da93b540