### PR TITLE
feat: add Mongo-backed session store

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bookshelf": "^0.10.4",
     "bulma": "^0.4.3",
     "cors": "^2.8.4",
+    "connect-mongo": "^4.6.0",
     "express": "^4.15.3",
     "express-session": "^1.17.1",
     "mongodb": "^2.2.30",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const morgan = require('morgan');
 const session = require('express-session');
+const MongoStore = require('connect-mongo');
 const config = require('./config');
 const bodyParser = require('body-parser');
 const cors = require('cors');
@@ -9,14 +10,17 @@ const { CLIENT_ORIGIN } = require('./config');
 const app = express();
 
 const sess = {
-	secret: config.SECRET,
-	name: 'SessionMgmt',
-	resave: false,
-	saveUninitialized: true,
-	cookie: {
-		path: '/',
-		maxAge: 5 * 60 * 1000 //min * seconds * miliseconds
-	}
+        secret: config.SECRET,
+        name: 'SessionMgmt',
+        resave: false,
+        saveUninitialized: true,
+        store: MongoStore.create({
+                mongoUrl: process.env.SESSION_DB_URL || 'mongodb://127.0.0.1:27017/sessions'
+        }),
+        cookie: {
+                path: '/',
+                maxAge: 30 * 60 * 1000 //min * seconds * miliseconds
+        }
 };
 
 const playerRouter = require('./api/routes/playerRouter');


### PR DESCRIPTION
## Summary
- configure sessions to use a MongoDB store via connect-mongo
- extend session cookie lifespan to 30 minutes

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68941d1c4de083288e7d78765b6f1093