### PR TITLE
Use persistent session store with secure cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cors": "^2.8.4",
     "express": "^4.15.3",
     "express-session": "^1.17.1",
+    "connect-pg-simple": "^7.0.0",
     "mongodb": "^2.2.30",
     "morgan": "^1.10.0",
     "pg": "^6.4.2",

--- a/server.js
+++ b/server.js
@@ -1,21 +1,28 @@
 const express = require('express');
 const morgan = require('morgan');
 const session = require('express-session');
+const PGSession = require('connect-pg-simple')(session);
 const bodyParser = require('body-parser');
 const cors = require('cors');
-const { SECRET, CLIENT_ORIGIN } = require('./config');
+const { SECRET, CLIENT_ORIGIN, DATABASE_URL } = require('./config');
 
 const app = express();
 
 const sess = {
+        store: new PGSession({
+                conString: DATABASE_URL
+        }),
         secret: SECRET,
-	name: 'SessionMgmt',
-	resave: false,
-	saveUninitialized: true,
-	cookie: {
-		path: '/',
-		maxAge: 5 * 60 * 1000 //min * seconds * miliseconds
-	}
+        name: 'SessionMgmt',
+        resave: false,
+        saveUninitialized: false,
+        cookie: {
+                path: '/',
+                maxAge: 5 * 60 * 1000, //min * seconds * milliseconds
+                httpOnly: true,
+                secure: process.env.NODE_ENV === 'production',
+                sameSite: 'strict'
+        }
 };
 
 const playerRouter = require('./api/routes/playerRouter');


### PR DESCRIPTION
## Summary
- add connect-pg-simple dependency
- configure express-session to persist sessions in PostgreSQL and set secure cookie flags

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68941fe1ffa88328b1d07a937de49d63