### PR TITLE
Require SECRET env var and document configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for highlander-react-redux
+DATABASE_URL=postgresql://localhost/highlander-react-redux
+CLIENT_ORIGIN=http://localhost:3000
+SECRET=replace-with-secure-random-string

--- a/config.js
+++ b/config.js
@@ -1,5 +1,13 @@
+const DATABASE_URL = process.env.DATABASE_URL || 'postgresql://localhost/highlander-react-redux';
+const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN || 'http://localhost:3000';
+const SECRET = process.env.SECRET;
+
+if (!SECRET) {
+  throw new Error('SECRET environment variable is required');
+}
+
 module.exports = {
-  DATABASE_URL: process.env.DATABASE_URL || 'postgresql://localhost/highlander-react-redux',
-  CLIENT_ORIGIN: process.env.CLIENT_ORIGIN || 'http://localhost:3000',
-  SECRET: process.env.SECRET || 'super-secret'
+  DATABASE_URL,
+  CLIENT_ORIGIN,
+  SECRET
 };


### PR DESCRIPTION
## Summary
- enforce presence of SECRET environment variable
- provide example `.env` file showing required values

## Testing
- `node -e "require('./config')"` *(fails: SECRET environment variable is required)*
- `SECRET=test npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68941fe221cc8328a65267122e045d98