### PR TITLE
Add tests and CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: node_js
 node_js: node
+script:
+  - npm test
+  - npm run build

--- a/src/actions/coachAction.test.js
+++ b/src/actions/coachAction.test.js
@@ -1,0 +1,21 @@
+import { PROFILE_SUCCESS, profileSuccess, PROFILE_ERROR, profileError } from './coachAction';
+
+describe('coach actions', () => {
+  it('should create profileSuccess action', () => {
+    const response = { data: {} };
+    const expected = {
+      type: PROFILE_SUCCESS,
+      response
+    };
+    expect(profileSuccess(response)).toEqual(expected);
+  });
+
+  it('should create profileError action', () => {
+    const response = 'err';
+    const expected = {
+      type: PROFILE_ERROR,
+      response
+    };
+    expect(profileError(response)).toEqual(expected);
+  });
+});

--- a/src/actions/loginAction.test.js
+++ b/src/actions/loginAction.test.js
@@ -1,0 +1,34 @@
+import { LOGIN_SUCCESS, loginSuccess, LOGIN_FAIL, loginFail, LOGOUT, logout } from './loginAction';
+
+// Test synchronous action creators
+
+describe('login actions', () => {
+  it('should create an action for loginSuccess', () => {
+    const response = { data: { token: '123' } };
+    const expectedAction = {
+      type: LOGIN_SUCCESS,
+      response
+    };
+    expect(loginSuccess(response)).toEqual(expectedAction);
+  });
+
+  it('should create an action for loginFail', () => {
+    const err = 'error';
+    const expectedAction = {
+      type: LOGIN_FAIL,
+      err
+    };
+    expect(loginFail(err)).toEqual(expectedAction);
+  });
+
+  it('should create an action for logout', () => {
+    const email = 'test@example.com';
+    const pwd = 'pwd';
+    const expectedAction = {
+      type: LOGOUT,
+      email,
+      pwd
+    };
+    expect(logout(email, pwd)).toEqual(expectedAction);
+  });
+});

--- a/src/actions/teamAction.test.js
+++ b/src/actions/teamAction.test.js
@@ -1,0 +1,60 @@
+import {
+  CREATE_TEAM,
+  createTeam,
+  HIDE_MODAL,
+  hideModal,
+  ADD_PLAYER,
+  addPlayer,
+  ADD_PLAYER_ERROR,
+  addPlayerError,
+  GET_TEAM_PROFILE_SUCCESS,
+  getTeamProfileSuccess,
+  GET_TEAM_PROFILE_ERROR,
+  getTeamProfileError
+} from './teamAction';
+
+describe('team actions', () => {
+  it('should create an action to show modal', () => {
+    expect(createTeam()).toEqual({ type: CREATE_TEAM });
+  });
+
+  it('should create an action to hide modal', () => {
+    expect(hideModal()).toEqual({ type: HIDE_MODAL });
+  });
+
+  it('should create addPlayer action', () => {
+    const response = { data: { first_name: 'a', last_name: 'b', email: 'e', position: 'p' } };
+    const expected = {
+      type: ADD_PLAYER,
+      response
+    };
+    expect(addPlayer(response)).toEqual(expected);
+  });
+
+  it('should create addPlayerError action', () => {
+    const response = 'err';
+    const expected = {
+      type: ADD_PLAYER_ERROR,
+      response
+    };
+    expect(addPlayerError(response)).toEqual(expected);
+  });
+
+  it('should create getTeamProfileSuccess action', () => {
+    const response = { data: {} };
+    const expected = {
+      type: GET_TEAM_PROFILE_SUCCESS,
+      response
+    };
+    expect(getTeamProfileSuccess(response)).toEqual(expected);
+  });
+
+  it('should create getTeamProfileError action', () => {
+    const response = 'err';
+    const expected = {
+      type: GET_TEAM_PROFILE_ERROR,
+      response
+    };
+    expect(getTeamProfileError(response)).toEqual(expected);
+  });
+});

--- a/src/reducers/coachReducer.test.js
+++ b/src/reducers/coachReducer.test.js
@@ -1,0 +1,55 @@
+import { coachReducer } from './coachReducer';
+import { LOGIN_SUCCESS } from '../actions/loginAction';
+import { PROFILE_SUCCESS } from '../actions/coachAction';
+
+describe('coachReducer', () => {
+  it('should handle LOGIN_SUCCESS', () => {
+    const action = { type: LOGIN_SUCCESS, response: { data: { id: 2 } } };
+    const state = coachReducer(undefined, action);
+    expect(state.id).toBe(2);
+  });
+
+  it('should handle PROFILE_SUCCESS', () => {
+    const action = {
+      type: PROFILE_SUCCESS,
+      response: {
+        data: {
+          teams: [
+            {
+              players: [
+                {
+                  id: 1,
+                  first_name: 'P',
+                  last_name: 'One',
+                  position: 'Pitcher',
+                  stats: [
+                    { description: 'Hits', _pivot_how_many: 5 },
+                    { description: 'At Bats', _pivot_how_many: 10 }
+                  ]
+                },
+                {
+                  id: 1,
+                  first_name: 'P',
+                  last_name: 'One',
+                  position: 'Pitcher',
+                  stats: [
+                    { description: 'Hits', _pivot_how_many: 5 },
+                    { description: 'At Bats', _pivot_how_many: 10 }
+                  ]
+                }
+              ]
+            }
+          ],
+          first_name: 'Coach',
+          last_name: 'Test',
+          email: 'c@example.com',
+          id: 1
+        }
+      }
+    };
+    const state = coachReducer(undefined, action);
+    expect(state.first_name).toBe('Coach');
+    expect(state.players).toHaveLength(1);
+    expect(state.stats[0].stats.Hits).toBe(5);
+  });
+});

--- a/src/reducers/loginReducer.test.js
+++ b/src/reducers/loginReducer.test.js
@@ -1,0 +1,48 @@
+import { loginReducer } from './loginReducer';
+import { LOGIN_REQUEST, LOGIN_SUCCESS, LOGIN_FAIL, LOGOUT } from '../actions/loginAction';
+
+describe('loginReducer', () => {
+  it('should handle LOGIN_REQUEST', () => {
+    const state = loginReducer(undefined, { type: LOGIN_REQUEST });
+    expect(state).toEqual({
+      isLoading: true,
+      isloggedIn: false,
+      shouldRedirect: false,
+      errorMessage: null
+    });
+  });
+
+  it('should handle LOGIN_SUCCESS', () => {
+    const state = loginReducer(undefined, { type: LOGIN_SUCCESS });
+    expect(state.isLoading).toBe(false);
+    expect(state.isloggedIn).toBe(true);
+    expect(state.shouldRedirect).toBe(true);
+  });
+
+  it('should handle LOGIN_FAIL', () => {
+    const err = 'bad';
+    const state = loginReducer(undefined, { type: LOGIN_FAIL, err });
+    expect(state).toEqual({
+      isLoading: false,
+      isloggedIn: false,
+      shouldRedirect: false,
+      errorMessage: err
+    });
+  });
+
+  it('should handle LOGOUT', () => {
+    const prevState = {
+      isLoading: false,
+      isloggedIn: true,
+      shouldRedirect: true,
+      errorMessage: null
+    };
+    const state = loginReducer(prevState, { type: LOGOUT });
+    expect(state).toEqual({
+      isLoading: false,
+      isloggedIn: false,
+      shouldRedirect: false,
+      errorMessage: null
+    });
+  });
+});

--- a/src/reducers/teamReducer.test.js
+++ b/src/reducers/teamReducer.test.js
@@ -1,0 +1,60 @@
+import { teamReducer } from './teamReducer';
+import {
+  GET_TEAM_PROFILE_SUCCESS,
+  ADD_PLAYER,
+  CREATE_TEAM,
+  HIDE_MODAL
+} from '../actions/teamAction';
+
+describe('teamReducer', () => {
+  it('should handle GET_TEAM_PROFILE_SUCCESS', () => {
+    const action = {
+      type: GET_TEAM_PROFILE_SUCCESS,
+      response: {
+        data: {
+          name: 'T',
+          city: 'C',
+          state: 'S',
+          players: [
+            { first_name: 'P', last_name: 'L', email: 'e', position: 'p' }
+          ],
+          coach: [
+            { first_name: 'C', last_name: 'L', email: 'c' }
+          ]
+        }
+      }
+    };
+    const state = teamReducer(undefined, action);
+    expect(state).toEqual({
+      name: 'T',
+      city: 'C',
+      state: 'S',
+      players: [
+        { first_name: 'P', last_name: 'L', email: 'e', position: 'p' }
+      ],
+      coach: { first_name: 'C', last_name: 'L', email: 'c' },
+      errorMessage: null,
+      showModal: false
+    });
+  });
+
+  it('should handle ADD_PLAYER', () => {
+    const initial = teamReducer(undefined, { type: '@@INIT' });
+    const action = {
+      type: ADD_PLAYER,
+      response: {
+        data: { first_name: 'N', last_name: 'P', email: 'n', position: 's' }
+      }
+    };
+    const state = teamReducer(initial, action);
+    expect(state.players).toHaveLength(1);
+    expect(state.players[0].first_name).toBe('N');
+  });
+
+  it('should toggle modal with CREATE_TEAM and HIDE_MODAL', () => {
+    const opened = teamReducer(undefined, { type: CREATE_TEAM });
+    expect(opened.showModal).toBe(true);
+    const closed = teamReducer(opened, { type: HIDE_MODAL });
+    expect(closed.showModal).toBe(false);
+  });
+});

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment node
+ */
+
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const { app } = require('../server');
+
+chai.use(chaiHttp);
+const expect = chai.expect;
+
+describe('server routes', () => {
+  it('DELETE /sessions should return 204', () => {
+    return chai
+      .request(app)
+      .delete('/sessions')
+      .then(res => {
+        expect(res).to.have.status(204);
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- add Travis script to run tests and build
- add unit tests for actions and reducers
- add basic server route test

## Testing
- `CI=true npm test` (fails: react-scripts: not found)
- `CI=true npm run build` (fails: react-scripts: not found)


------
https://chatgpt.com/codex/tasks/task_e_68941fe46f68832896b3d4ad0e9d7969