### PR TITLE
Modernize dependencies and add lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,39 +3,40 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "axios": "^0.21.1",
+    "axios": "^1.6.0",
     "bcrypt": "^5.1.0",
-    "bluebird": "^3.5.0",
-    "body-parser": "^1.17.2",
-    "bookshelf": "^0.10.4",
-    "bulma": "^0.4.3",
-    "cors": "^2.8.4",
-    "express": "^4.15.3",
-    "express-session": "^1.17.1",
-    "connect-pg-simple": "^7.0.0",
-    "mongodb": "^2.2.30",
+    "bluebird": "^3.7.2",
+    "body-parser": "^1.20.2",
+    "bookshelf": "^1.2.0",
+    "bulma": "^0.9.4",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "connect-pg-simple": "^9.0.0",
+    "mongodb": "^5.8.0",
     "morgan": "^1.10.0",
-    "pg": "^6.4.2",
-    "radium": "^0.19.4",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
-    "react-redux": "^5.0.6",
-    "react-router-dom": "^4.1.2",
-    "redux": "^3.7.2",
-    "redux-form": "^7.4.3",
+    "pg": "^8.11.5",
+    "radium": "^0.26.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-redux": "^8.1.1",
+    "react-router-dom": "^5.3.4",
+    "redux": "^5.0.1",
+    "redux-form": "^8.3.10",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.2.0",
-    "sqlite": "^4.0.19",
-    "sqlite3": "^5.0.1"
+    "redux-thunk": "^2.4.2",
+    "sqlite": "^4.1.2",
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
-    "chai": "^4.0.2",
-    "chai-http": "^3.0.0",
-    "eslint": "^3.19.0",
-    "knex": "^0.21.17",
-    "mocha": "^3.4.2",
-    "nodemon": "^1.11.0",
-    "react-scripts": "1.0.10"
+    "chai": "^4.3.8",
+    "chai-http": "^4.3.0",
+    "eslint": "^8.53.0",
+    "eslint-plugin-react": "^7.33.2",
+    "knex": "^2.5.1",
+    "mocha": "^10.2.0",
+    "nodemon": "^3.0.3",
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "node server.js",
@@ -44,11 +45,10 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "migrate": "knex migrate:latest",
-    "seed": "knex seed:run"
+    "seed": "knex seed:run",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint ."
   },
   "engines": {
     "node": ">=14"
-    "seed": "knex seed:run",
-    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint ."
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,15 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import store from './store';
 
 import App from './container/App';
 import registerServiceWorker from './registerServiceWorker';
 
-ReactDOM.render(
-	<Provider store={store}>
-		<App />
-	</Provider>,
-	document.getElementById('root'));
+const root = createRoot(document.getElementById('root'));
+root.render(
+        <Provider store={store}>
+                <App />
+        </Provider>
+);
 registerServiceWorker();


### PR DESCRIPTION
## Summary
- update core libraries and tooling to modern versions
- replace legacy ReactDOM render with React 18 createRoot
- expose eslint via `npm run lint` and drop non-node engine entries

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/axios)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68942c86d2c08328ad3f065f10a31987