### PR TITLE
Remove sensitive logging from coach and other routes

### DIFF
--- a/api/models/Coach.js
+++ b/api/models/Coach.js
@@ -12,11 +12,10 @@ const CoachSchema = Bookshelf.Model.extend({
 	}
 },
 {
-	hashPassword: function(password) {
-		let hashed = Bcrypt.hash(password, saltRounds);
-    console.log('This is the hashed paassword for this instance', hashed)
-		return hashed;
-	},
+        hashPassword: function(password) {
+                let hashed = Bcrypt.hash(password, saltRounds);
+                return hashed;
+        },
 	validatePassword: function(hashedPassword, plainTextPassword) {
 		return Bcrypt.compare(plainTextPassword, hashedPassword);
 	}

--- a/api/routes/coachRouter.js
+++ b/api/routes/coachRouter.js
@@ -33,17 +33,6 @@ router.get('/:id', function(req, res) {
 		});
 });
 
-router.get('/hashed/:password', function(req, res){
-	console.log(req.params.password)
-	Coach.hashPassword(req.params.password)
-		.then(password => {
-			console.log(password)
-			res.status(200)
-				.json({hashedPassword: password});
-		})
-
-})
-
 router.post('/', function(req, res) {
         const postParams = ['email', 'first_name', 'last_name', 'password'];
 	for (var i = 0; i < postParams.length; i++) {

--- a/api/routes/playerRouter.js
+++ b/api/routes/playerRouter.js
@@ -25,7 +25,6 @@ router.get('/:id', function(req, res) {
   .where({id: parseInt(req.params.id)})
   .fetch({withRelated: ['teams']})
   .then(function(players) {
-    console.log('players', players)
     res.json(players);
   })
 })
@@ -160,12 +159,11 @@ router.post('/', function(req, res) {
 
  router.delete('/:id', function(req, res) {
    const deleteParams = ['id']
-   for(var i = 0; i < deleteParams.length; i++) {
-     const wrongId = deleteParams[i];
-     console.log(':: wrong id is here =====> ::', wrongId)
-     if(!(wrongId in req.params)){
-       const errorMessage = `Sorry your missing ${wrongId} please try again`
-       console.error(errorMessage);
+  for(var i = 0; i < deleteParams.length; i++) {
+    const wrongId = deleteParams[i];
+    if(!(wrongId in req.params)){
+      const errorMessage = `Sorry your missing ${wrongId} please try again`
+      console.error(errorMessage);
        return res.status(400).send(errorMessage);
      }
    }

--- a/api/routes/teamRouter.js
+++ b/api/routes/teamRouter.js
@@ -23,11 +23,10 @@ router.get('/', function(req, res) {
 router.get('/:id', function(req, res) {
 	Team
 		.where({id: req.params.id})
-		.fetch({withRelated: ['coach', 'players']})
-		.then(function(teams) {
-			console.log(teams);
-			res.json(teams);
-		});
+               .fetch({withRelated: ['coach', 'players']})
+               .then(function(teams) {
+                        res.json(teams);
+               });
 });
 
 router.put('/:id', function(req, res) {


### PR DESCRIPTION
## Summary
- remove debug log from coach password hashing
- drop unprotected `hashed/:password` endpoint
- strip console logging from player and team routes

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68942c889194832897d0de2a29cfdd75