### PR TITLE
Refactor server tests to use Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,11 @@
     "sqlite3": "^5.0.1"
   },
   "devDependencies": {
-    "chai": "^4.0.2",
-    "chai-http": "^3.0.0",
     "eslint": "^3.19.0",
     "knex": "^0.21.17",
-    "mocha": "^3.4.2",
     "nodemon": "^1.11.0",
-    "react-scripts": "1.0.10"
+    "react-scripts": "1.0.10",
+    "supertest": "^6.3.3"
   },
   "scripts": {
     "start": "node server.js",
@@ -48,7 +46,5 @@
   },
   "engines": {
     "node": ">=14"
-    "seed": "knex seed:run",
-    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint ."
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const morgan = require('morgan');
 const session = require('express-session');
-const PGSession = require('connect-pg-simple')(session);
 const bodyParser = require('body-parser');
 const cors = require('cors');
 const { SECRET, CLIENT_ORIGIN, DATABASE_URL } = require('./config');
@@ -9,10 +8,18 @@ const path = require('path');
 
 const app = express();
 
-const sess = {
-        store: new PGSession({
+let store;
+if (process.env.NODE_ENV === 'test') {
+        store = new session.MemoryStore();
+} else {
+        const PGSession = require('connect-pg-simple')(session);
+        store = new PGSession({
                 conString: DATABASE_URL
-        }),
+        });
+}
+
+const sess = {
+        store,
         secret: SECRET,
         name: 'SessionMgmt',
         resave: false,

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -2,20 +2,13 @@
  * @jest-environment node
  */
 
-const chai = require('chai');
-const chaiHttp = require('chai-http');
+const request = require('supertest');
+
+process.env.SECRET = 'test-secret';
 const { app } = require('../server');
 
-chai.use(chaiHttp);
-const expect = chai.expect;
-
 describe('server routes', () => {
-  it('DELETE /sessions should return 204', () => {
-    return chai
-      .request(app)
-      .delete('/sessions')
-      .then(res => {
-        expect(res).to.have.status(204);
-      });
+  it('DELETE /sessions should return 204', async () => {
+    await request(app).delete('/sessions').expect(204);
   });
 });


### PR DESCRIPTION
## Summary
- replace Chai-based HTTP test with Jest and supertest
- configure express session to use in-memory store during tests
- remove unused Mocha/Chai deps and tidy package.json

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden fetching axios)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68942c88db7c832895e50402ecb4ba4b