### PR TITLE
docs: document env vars and load from dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /codeArchitecture
 
 # misc
+.env
 .DS_Store
 .env.local
 .env.development.local

--- a/README.md
+++ b/README.md
@@ -27,13 +27,21 @@ Want to keep up with the development and roadmap of Highlander?  https://trello.
    ```
 
 ### Environment variables
-Set the following variables in your shell or a `.env` file before starting the server:
+Set the following variables in your shell or copy `.env.example` to `.env` before starting the server:
 
 ```
 DATABASE_URL=postgresql://localhost/highlander-react-redux
 CLIENT_ORIGIN=http://localhost:3000
 SECRET=super-secret
 PORT=8080
+```
+
+The server loads these values from the environment and, during local development, from a `.env` file via [dotenv](https://www.npmjs.com/package/dotenv).
+
+On hosting platforms such as Heroku, configure the required variables with:
+
+```
+heroku config:set SECRET=your-secret DATABASE_URL=your-database-url CLIENT_ORIGIN=https://your-client-app
 ```
 
 ### Run database migrations
@@ -49,7 +57,7 @@ npm start
 
 ### Troubleshooting
 - **Heroku or similar platforms:**
-  - Ensure all environment variables above are configured with `heroku config:set ...`.
+  - Ensure `SECRET`, `DATABASE_URL`, and `CLIENT_ORIGIN` are configured with `heroku config:set`.
   - Run migrations on the remote instance with `heroku run npm run migrate`.
   - If the build fails, verify the Node.js buildpack is enabled and that `npm run build` succeeds locally before deploying.
 

--- a/config.js
+++ b/config.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const DATABASE_URL = process.env.DATABASE_URL || 'postgresql://localhost/highlander-react-redux';
 const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN || 'http://localhost:3000';
 const SECRET = process.env.SECRET;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "mongodb": "^5.8.0",
     "morgan": "^1.10.0",
     "pg": "^8.11.5",
+    "dotenv": "^16.3.1",
     "radium": "^0.26.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -33,7 +34,7 @@
     "knex": "^0.21.17",
     "nodemon": "^1.11.0",
     "react-scripts": "1.0.10",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
     "chai": "^4.3.8",
     "chai-http": "^4.3.0",
     "eslint": "^8.53.0",


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file via `dotenv`
- document required `SECRET`, `DATABASE_URL`, and `CLIENT_ORIGIN`
- ignore local `.env` files

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/axios)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_6894320017508328adf2be4269e303a2