### PR TITLE
fix devDependencies formatting and duplicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,7 @@
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
-    "eslint": "^3.19.0",
-    "knex": "^0.21.17",
-    "nodemon": "^1.11.0",
-    "react-scripts": "1.0.10",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
     "chai": "^4.3.8",
     "chai-http": "^4.3.0",
     "eslint": "^8.53.0",
@@ -42,7 +38,6 @@
     "mocha": "^10.2.0",
     "nodemon": "^3.0.3",
     "react-scripts": "^5.0.1"
-
   },
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
## Summary
- fix `devDependencies` JSON by removing duplicate `eslint`, `knex`, `nodemon`, and `react-scripts` entries
- add missing comma after `supertest`

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/axios)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894320c2440832896d34ee7f5177e20