### PR TITLE
feat: upgrade react-router-dom to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.1",
-    "react-router-dom": "^5.3.4",
+    "react-router-dom": "^6.22.3",
     "redux": "^5.0.1",
     "redux-form": "^8.3.10",
     "redux-logger": "^3.0.6",

--- a/src/container/App.js
+++ b/src/container/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { BrowserRouter as Router, Route} from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 import Home from '../pages/Home';
 import Login from '../pages/Login';
@@ -10,18 +10,20 @@ import TeamDetails from '../pages/TeamDetails';
 class App extends Component {
 	render() {
 		return (
-			<Router>
-				<div className="App">
-					<Route exact path='/' component={Home} />
-					<Route path='/login' component={Login} />
-					<Route path='/register' component={Register} />
-					<Route path='/dashboard' component={Dashboard} />
-					<Route path='/dashboard/:id' component={Dashboard} />
-					<Route path='/teamdetails/:id' component={TeamDetails} />
-				</div>
-			</Router>
-		);
-	}
+                        <Router>
+                                <div className="App">
+                                        <Routes>
+                                                <Route path='/' element={<Home />} />
+                                                <Route path='/login' element={<Login />} />
+                                                <Route path='/register' element={<Register />} />
+                                                <Route path='/dashboard' element={<Dashboard />} />
+                                                <Route path='/dashboard/:id' element={<Dashboard />} />
+                                                <Route path='/teamdetails/:id' element={<TeamDetails />} />
+                                        </Routes>
+                                </div>
+                        </Router>
+                );
+        }
 }
 
 export default App;

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,21 +1,19 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Route, Redirect, Router } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
-import { login, logout } from '../actions/loginAction';
-import { loginReducer } from '../reducers/loginReducer';
+import { login } from '../actions/loginAction';
 
 import Nav from '../components/Nav';
 import LoginForm from '../components/LoginForm';
 import Footer from '../components/Footer';
-import Dashboard from '../pages/Dashboard';
 
 class Login extends Component {
-	componentWillReceiveProps(nextProps){
-		if(nextProps.shouldRedirect) {
-			this.props.history.push('/dashboard');
-		}
-	}
+        componentDidUpdate(prevProps){
+                if(this.props.shouldRedirect && !prevProps.shouldRedirect) {
+                        this.props.navigate('/dashboard');
+                }
+        }
 
 	callLogin(email, pwd){
 		this.props.dispatch(login(email, pwd));
@@ -39,9 +37,14 @@ class Login extends Component {
 }
 
 const mapStateToProps = state => ({
-	loggedIn: state.loginReducer.isloggedIn,
-	error: state.loginReducer.errorMessage,
-	shouldRedirect: state.loginReducer.shouldRedirect,
+        loggedIn: state.loginReducer.isloggedIn,
+        error: state.loginReducer.errorMessage,
+        shouldRedirect: state.loginReducer.shouldRedirect,
 });
 
-export default connect(mapStateToProps)(Login);
+const ConnectedLogin = connect(mapStateToProps)(Login);
+
+export default function LoginWrapper(props) {
+        const navigate = useNavigate();
+        return <ConnectedLogin {...props} navigate={navigate} />;
+}


### PR DESCRIPTION
## Summary
- upgrade react-router-dom to the latest v6 release
- migrate routes to `<Routes>`/`element` API
- replace history-based navigation with `useNavigate`

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden registry access)*
- `npm run build` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6894353700e08328815b44392f5659dc