### PR TITLE
Add helmet middleware for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bookshelf": "^1.2.0",
     "bulma": "^0.9.4",
     "cors": "^2.8.5",
+    "helmet": "^7.0.0",
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "connect-pg-simple": "^9.0.0",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const morgan = require('morgan');
 const session = require('express-session');
 const bodyParser = require('body-parser');
 const cors = require('cors');
+const helmet = require('helmet');
 const { SECRET, CLIENT_ORIGIN, DATABASE_URL } = require('./config');
 const path = require('path');
 
@@ -40,6 +41,7 @@ const statRouter = require('./api/routes/statRouter');
 const sessionRouter = require('./api/routes/sessionRouter');
 
 
+app.use(helmet());
 app.use(morgan('common'));
 app.use(session(sess));
 app.use(bodyParser.json());


### PR DESCRIPTION
## Summary
- add helmet dependency for setting security headers
- apply helmet middleware before other express middleware

## Testing
- `npm test` *(fails: `react-scripts: not found`)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*


------
https://chatgpt.com/codex/tasks/task_e_6894353882d08328b42b147931b6f3e9