### PR TITLE
Enforce required environment variables in config

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,8 +1,16 @@
 require('dotenv').config();
 
-const DATABASE_URL = process.env.DATABASE_URL || 'postgresql://localhost/highlander-react-redux';
-const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN || 'http://localhost:3000';
+const DATABASE_URL = process.env.DATABASE_URL;
+const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN;
 const SECRET = process.env.SECRET;
+
+if (!DATABASE_URL) {
+  throw new Error('DATABASE_URL environment variable is required');
+}
+
+if (!CLIENT_ORIGIN) {
+  throw new Error('CLIENT_ORIGIN environment variable is required');
+}
 
 if (!SECRET) {
   throw new Error('SECRET environment variable is required');


### PR DESCRIPTION
## Summary
- validate presence of `DATABASE_URL` and `CLIENT_ORIGIN` env vars, throwing errors if missing
- remove default URLs to prevent accidental local connections

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: dependency resolution/403)*
- `npm run lint` *(fails: missing eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_6894353a06208328b9a3e0ec641c28b8