### PR TITLE
Handle missing coach on login

### DIFF
--- a/api/routes/sessionRouter.js
+++ b/api/routes/sessionRouter.js
@@ -24,8 +24,15 @@ router.post('/login', function(req, res){
                 .fetch()
                 .then(function(coach) {
                         coachData = coach;
+                        if(!coachData){
+                                res.status(404).json('Coach not found');
+                                return;
+                        }
                         return Coach.validatePassword(coachData.get('password'), req.body.pwd);
                 }).then(function(validPassword){
+                        if(!coachData){
+                                return;
+                        }
                         if(validPassword){
                                 req.session.coachId = coachData.id;
                                 res.status(200).json(coachData);


### PR DESCRIPTION
## Summary
- prevent access to null coach records when logging in
- return 404 when coach email not found

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: eslint not found)*
- `npm install` *(fails: dependency resolution for bookshelf/knex)*

------
https://chatgpt.com/codex/tasks/task_e_6894353ac86c83289c44ce9ded22d3a1