### PR TITLE
Add error handling to coach GET routes

### DIFF
--- a/api/routes/coachRouter.js
+++ b/api/routes/coachRouter.js
@@ -14,23 +14,31 @@ router.use(jsonParser);
 
 router.get('/', function(req, res) {
 	if(req.session.coachId){ // If the session doesn't have an userId(accessToken, etc...) then you don't show the protected token
-		Coach
-			.fetchAll()
-			.then(function(coaches) {
-				res.json(coaches);
-			});
+               Coach
+                        .fetchAll()
+                        .then(function(coaches) {
+                                res.json(coaches);
+                        })
+                        .catch(function(err) {
+                                console.error(err);
+                                return res.status(500).json(err);
+                        });
 	} else {
 		res.status(403).send('No session available');
 	}
 });
 
 router.get('/:id', function(req, res) {
-	Coach
-		.where({id: req.params.id})
-		.fetch({withRelated: ['teams', 'teams.players', 'teams.players.stats']})
-		.then(function(coaches) {
-			res.json(coaches);
-		});
+        Coach
+                .where({id: req.params.id})
+                .fetch({withRelated: ['teams', 'teams.players', 'teams.players.stats']})
+                .then(function(coaches) {
+                        res.json(coaches);
+                })
+                .catch(function(err) {
+                        console.error(err);
+                        return res.status(500).json(err);
+                });
 });
 
 router.post('/', function(req, res) {


### PR DESCRIPTION
## Summary
- add `.catch` handlers to coach list and detail GET endpoints
- log errors and return 500 status on DB failures

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: peer dependency conflict)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden for bulma)*
- `npm run lint` *(fails: eslint-plugin-react not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894353bdc4c83289c21390c81dca37e