### PR TITLE
Add catch handlers to player GET routes

### DIFF
--- a/api/routes/playerRouter.js
+++ b/api/routes/playerRouter.js
@@ -18,6 +18,10 @@ router.get('/', function(req, res) {
   .then(function(players) {
     res.json(players);
   })
+  .catch(function(err) {
+    console.error(err);
+    return res.status(500).json(err);
+  });
 })
 
 router.get('/:id', function(req, res) {
@@ -27,6 +31,10 @@ router.get('/:id', function(req, res) {
   .then(function(players) {
     res.json(players);
   })
+  .catch(function(err) {
+    console.error(err);
+    return res.status(500).json(err);
+  });
 })
 
 router.get('/:id/stats', function(req, res) {
@@ -36,6 +44,10 @@ router.get('/:id/stats', function(req, res) {
   .then(function(stats) {
     res.json(stats);
   })
+  .catch(function(err) {
+    console.error(err);
+    return res.status(500).json(err);
+  });
 })
 
 // update player


### PR DESCRIPTION
## Summary
- add error-catching middleware to player GET endpoints

## Testing
- `CI=true npm test` (fails: react-scripts not found)
- `npm run lint` (fails: ESLint plugin missing)

------
https://chatgpt.com/codex/tasks/task_e_6894353c68088328a564e98bd7f2cde3