### PR TITLE
refactor: destructure team details navigation props

### DIFF
--- a/src/components/TeamDetailsNavigation.js
+++ b/src/components/TeamDetailsNavigation.js
@@ -6,13 +6,7 @@ import '../css/style.css';
 
 export default function TeamDetailsNavigation(props) {
 
-	//TODO: look into storing all of this via deconstruction
-	const name = props.name;
-	const location = props.city;
-	const firstName = props.first_name;
-	const lastName = props.last_name;
-	const email = props.email;
-	const onClick = props.showModal;
+        const { name, city: location, first_name: firstName, last_name: lastName, email, showModal: onClick } = props;
 
 	return (
 		<section className="hero is-primary dashboard-bg-image">


### PR DESCRIPTION
## Summary
- use a single object destructuring for TeamDetailsNavigation props

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: dependency conflict and 403 Forbidden for bulma)*
- `npm run lint` *(fails: missing eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_6894383acb5c8328b1a81afa713c2632