### PR TITLE
Ensure base-10 parsing and safe player deletion

### DIFF
--- a/api/routes/playerRouter.js
+++ b/api/routes/playerRouter.js
@@ -26,7 +26,7 @@ router.get('/', function(req, res) {
 
 router.get('/:id', function(req, res) {
   Player
-  .where({id: parseInt(req.params.id)})
+  .where({id: parseInt(req.params.id, 10)})
   .fetch({withRelated: ['teams']})
   .then(function(players) {
     res.json(players);
@@ -153,15 +153,15 @@ router.post('/', function(req, res) {
      }
    }
 
-   PlayerStat
-   .forge({
-     player_id: parseInt(req.params.player_id),
-     stat_catalog_id: parseInt(req.params.stat_catalog_id),
-     how_many: req.body.how_many
-   })
-   .save()
-   .then(function(stat) {
-     return res.status(200).json(stat);
+  PlayerStat
+  .forge({
+    player_id: parseInt(req.params.player_id, 10),
+    stat_catalog_id: parseInt(req.params.stat_catalog_id, 10),
+    how_many: req.body.how_many
+  })
+  .save()
+  .then(function(stat) {
+    return res.status(200).json(stat);
    })
    .catch(function(err) {
      return res.status(500).json(err);
@@ -180,17 +180,23 @@ router.post('/', function(req, res) {
      }
    }
 
-   Player
-   .where({
-     id: parseInt(req.params.id)
-   })
-   .fetch()
-   .then(function(player){
-     return player.destroy();
-   })
-   .then(function (player){
-     return res.status(200).end()
-   })
+  Player
+  .where({
+    id: parseInt(req.params.id, 10)
+  })
+  .fetch()
+  .then(function(player){
+    if (!player) {
+      return res.status(404).json({ error: 'Player not found' });
+    }
+    return player.destroy()
+      .then(function () {
+        return res.status(200).end();
+      });
+  })
+  .catch(function(err) {
+    return res.status(500).json(err);
+  });
 })
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- Explicitly specify radix 10 for all `parseInt` usages in `playerRouter`
- Handle missing players in delete handler and return 404 before attempting to destroy

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*


------
https://chatgpt.com/codex/tasks/task_e_6894383c1b5c832893f1d67db257e153