### PR TITLE
docs: add default port to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 DATABASE_URL=postgresql://localhost/highlander-react-redux
 CLIENT_ORIGIN=http://localhost:3000
 SECRET=replace-with-secure-random-string
+PORT=8080


### PR DESCRIPTION
## Summary
- document default PORT variable in sample env file

## Testing
- `CI=true npm test` *(fails: react-scripts: not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - bulma)*
- `npm run lint` *(fails: ESLint couldn't find eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68943b2c4fb48328a202c289ea8d34eb