### PR TITLE
Enable credentialed API requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ app.use(session(sess));
 app.use(bodyParser.json());
 app.use(express.static('public'));
 app.use(express.static('build'));
-app.use(cors({ origin: CLIENT_ORIGIN }));
+app.use(cors({ origin: CLIENT_ORIGIN, credentials: true }));
 
 app.use('/players', playerRouter);
 app.use('/coaches', coachRouter);

--- a/src/actions/coachAction.js
+++ b/src/actions/coachAction.js
@@ -7,8 +7,8 @@ export const getProfile = id => dispatch => {
 		type: GET_PROFILE,
 		id
 	});
-	axios.get(`${url}${id}`)
-		.then(response =>  {
+       axios.get(`${url}${id}`, { withCredentials: true })
+               .then(response =>  {
 			if(response.status === 200) {
 				dispatch(profileSuccess(response));
 			}

--- a/src/actions/loginAction.js
+++ b/src/actions/loginAction.js
@@ -8,8 +8,8 @@ export const login = (email, pwd) => dispatch => {
 		email,
 		pwd
 	});
-	axios.post(url, {email, pwd})
-		.then(response => {
+       axios.post(url, {email, pwd}, { withCredentials: true })
+               .then(response => {
 			if(response.status === 200){
 				dispatch(loginSuccess(response));
 			}

--- a/src/actions/teamAction.js
+++ b/src/actions/teamAction.js
@@ -11,8 +11,8 @@ export const getTeamProfile = id => dispatch => {
 		type: GET_TEAM_PROFILE,
 		id
 	});
-	axios.get(`${teamsUrl}${id}`)
-		.then(response => {
+       axios.get(`${teamsUrl}${id}`, { withCredentials: true })
+               .then(response => {
 			if(response.status === 200) {
 				dispatch(getTeamProfileSuccess(response));
 			}
@@ -34,13 +34,17 @@ export const addNewPlayer = (id, emailInput, firstName, lastName, position) => d
 		lastName,
 		position
 	});
-	axios.post(`${teamsUrl}${id}/player`, {
-		email: emailInput,
-		first_name: firstName,
-		last_name: lastName,
-		position
-	})
-		.then(response => {
+       axios.post(
+               `${teamsUrl}${id}/player`,
+               {
+                       email: emailInput,
+                       first_name: firstName,
+                       last_name: lastName,
+                       position
+               },
+               { withCredentials: true }
+       )
+               .then(response => {
 			console.log('check to see if all the right values are in this payload ====>', response);
 			if(response.status === 200) {
 				dispatch(addPlayer(response));

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -74,7 +74,7 @@ function registerValidSW(swUrl) {
 
 function checkValidServiceWorker(swUrl) {
   // Check if the service worker can be found. If it can't reload the page.
-  fetch(swUrl)
+  fetch(swUrl, { credentials: 'include' })
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
       if (


### PR DESCRIPTION
## Summary
- allow credentialed cross-origin requests by enabling `credentials: true` in CORS
- include cookies with frontend axios and fetch calls

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden fetching bulma)*

------
https://chatgpt.com/codex/tasks/task_e_68943b2d3a848328b9429b4e2a327870