### PR TITLE
Add session-based auth middleware for protected routes

### DIFF
--- a/api/middleware/ensureAuthenticated.js
+++ b/api/middleware/ensureAuthenticated.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function ensureAuthenticated(req, res, next) {
+  if (req.session && req.session.coachId) {
+    return next();
+  }
+  return res.status(403).send('No session available');
+}
+
+module.exports = ensureAuthenticated;

--- a/api/routes/coachRouter.js
+++ b/api/routes/coachRouter.js
@@ -6,6 +6,7 @@ const bodyParser = require('body-parser');
 const jsonParser = bodyParser.json();
 
 const Coach = require('../models/Coach');
+const ensureAuthenticated = require('../middleware/ensureAuthenticated');
 
 router.use(bodyParser.urlencoded({
 	extended: true
@@ -41,7 +42,7 @@ router.get('/:id', function(req, res) {
                 });
 });
 
-router.post('/', function(req, res) {
+router.post('/', ensureAuthenticated, function(req, res) {
         const postParams = ['email', 'first_name', 'last_name', 'password'];
 	for (var i = 0; i < postParams.length; i++) {
 		const confirmPostParams = postParams[i];
@@ -70,7 +71,7 @@ router.post('/', function(req, res) {
 		})
 })
 
-router.put('/:id', function(req, res) {
+router.put('/:id', ensureAuthenticated, function(req, res) {
 	// check to see if the proper params is equal to what the user is inputting
 	const updateParams = ['email', 'first_name', 'last_name']
 	for(var i = 0; i < updateParams.length; i++) {

--- a/api/routes/playerRouter.js
+++ b/api/routes/playerRouter.js
@@ -8,6 +8,7 @@ const jsonParser = bodyParser.json();
 const Player = require('../models/Player');
 const Stat_Catalog = require('../models/Stat_Catalog');
 const PlayerStat = require('../models/PlayerStat');
+const ensureAuthenticated = require('../middleware/ensureAuthenticated');
 
 router.use(bodyParser.urlencoded({extended: true}));
 router.use(jsonParser);
@@ -51,7 +52,7 @@ router.get('/:id/stats', function(req, res) {
 })
 
 // update player
-router.put('/:id', function(req, res) {
+router.put('/:id', ensureAuthenticated, function(req, res) {
 	// check to see if the proper params is equal to what the user is inputting
 	const updateParams = ['email', 'first_name', 'last_name', 'position'];
 	for(var i = 0; i < updateParams.length; i++) {
@@ -83,7 +84,7 @@ router.put('/:id', function(req, res) {
 });
 
 // update a stat tied to a player
- router.put('/:player_id/stats/:stat_catalog_id', function(req, res) {
+ router.put('/:player_id/stats/:stat_catalog_id', ensureAuthenticated, function(req, res) {
    const postParams = ['how_many'];
    for (var i = 0; i < postParams.length; i++) {
      const confirmPutParams = postParams[i];
@@ -114,7 +115,7 @@ router.put('/:id', function(req, res) {
  })
 
 // post new player
-router.post('/', function(req, res) {
+router.post('/', ensureAuthenticated, function(req, res) {
 	const postParams = ['email', 'first_name', 'last_name', 'position'];
 	for (var i = 0; i < postParams.length; i++) {
 		const confirmPostParams = postParams[i];
@@ -142,7 +143,7 @@ router.post('/', function(req, res) {
 });
 
 // post a new stat for a player
- router.post('/:player_id/stats/:stat_catalog_id', function(req, res) {
+ router.post('/:player_id/stats/:stat_catalog_id', ensureAuthenticated, function(req, res) {
    const postParams = ['how_many'];
    for (var i = 0; i < postParams.length; i++) {
      const confirmPostParams = postParams[i];
@@ -169,7 +170,7 @@ router.post('/', function(req, res) {
  })
 
 
- router.delete('/:id', function(req, res) {
+ router.delete('/:id', ensureAuthenticated, function(req, res) {
    const deleteParams = ['id']
   for(var i = 0; i < deleteParams.length; i++) {
     const wrongId = deleteParams[i];
@@ -197,6 +198,6 @@ router.post('/', function(req, res) {
   .catch(function(err) {
     return res.status(500).json(err);
   });
-})
+ })
 
 module.exports = router;

--- a/api/routes/sessionRouter.js
+++ b/api/routes/sessionRouter.js
@@ -6,6 +6,7 @@ const bodyParser = require('body-parser');
 const jsonParser = bodyParser.json();
 
 const Coach = require('../models/Coach');
+const ensureAuthenticated = require('../middleware/ensureAuthenticated');
 
 router.use(bodyParser.urlencoded({
         extended: true
@@ -48,7 +49,7 @@ router.post('/login', function(req, res){
 /*
  * Logout and destroy the current session
  */
-router.delete('/', function(req, res) {
+router.delete('/', ensureAuthenticated, function(req, res) {
         req.session.destroy();
         res.sendStatus(204);
 });

--- a/api/routes/teamRouter.js
+++ b/api/routes/teamRouter.js
@@ -7,6 +7,7 @@ const jsonParser = bodyParser.json();
 const Team = require('../models/Team');
 const Player = require('../models/Player');
 const Coaches = require('../models/Coach');
+const ensureAuthenticated = require('../middleware/ensureAuthenticated');
 
 router.use(bodyParser.urlencoded({extended: true}));
 router.use(jsonParser);
@@ -29,7 +30,7 @@ router.get('/:id', function(req, res) {
                });
 });
 
-router.put('/:id', function(req, res) {
+router.put('/:id', ensureAuthenticated, function(req, res) {
 	// check to see if the proper params is equal to what the user is inputting
 	const updateParams = ['name', 'city', 'state'];
 	for(var i = 0; i < updateParams.length; i++) {
@@ -60,7 +61,7 @@ router.put('/:id', function(req, res) {
 		});
 });
 
-router.post('/', function(req, res) {
+router.post('/', ensureAuthenticated, function(req, res) {
         const postParams = ['name', 'city', 'state', 'coachId'];
         for (var i = 0; i < postParams.length; i++) {
                 const confirmPostParams = postParams[i];
@@ -104,7 +105,7 @@ router.post('/', function(req, res) {
                 });
 });
 
-router.post('/:id/player', function(req, res) {
+router.post('/:id/player', ensureAuthenticated, function(req, res) {
   const postParams = ['email', 'first_name', 'last_name', 'position']
   for (var i = 0; i < postParams.length; i++) {
     const confirmPostParams = postParams[i];


### PR DESCRIPTION
## Summary
- add ensureAuthenticated middleware checking `req.session.coachId`
- guard player, team, coach and session routers' mutating routes with authentication

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin "eslint-plugin-react")*
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68943b2f72208328aa93185f9da95035