### PR TITLE
feat: centralize error handling

### DIFF
--- a/api/routes/coachRouter.js
+++ b/api/routes/coachRouter.js
@@ -12,7 +12,7 @@ router.use(bodyParser.urlencoded({
 }));
 router.use(jsonParser);
 
-router.get('/', function(req, res) {
+router.get('/', function(req, res, next) {
 	if(req.session.coachId){ // If the session doesn't have an userId(accessToken, etc...) then you don't show the protected token
                Coach
                         .fetchAll()
@@ -20,15 +20,14 @@ router.get('/', function(req, res) {
                                 res.json(coaches);
                         })
                         .catch(function(err) {
-                                console.error(err);
-                                return res.status(500).json(err);
+                                return next(err);
                         });
 	} else {
 		res.status(403).send('No session available');
 	}
 });
 
-router.get('/:id', function(req, res) {
+router.get('/:id', function(req, res, next) {
         Coach
                 .where({id: req.params.id})
                 .fetch({withRelated: ['teams', 'teams.players', 'teams.players.stats']})
@@ -36,12 +35,11 @@ router.get('/:id', function(req, res) {
                         res.json(coaches);
                 })
                 .catch(function(err) {
-                        console.error(err);
-                        return res.status(500).json(err);
+                        return next(err);
                 });
 });
 
-router.post('/', function(req, res) {
+router.post('/', function(req, res, next) {
         const postParams = ['email', 'first_name', 'last_name', 'password'];
 	for (var i = 0; i < postParams.length; i++) {
 		const confirmPostParams = postParams[i];
@@ -66,11 +64,11 @@ router.post('/', function(req, res) {
 			return res.status(200).json(coach);
 		})
 		.catch(function(err){
-			return res.status(500).json(err);
+			return next(err);
 		})
 })
 
-router.put('/:id', function(req, res) {
+router.put('/:id', function(req, res, next) {
 	// check to see if the proper params is equal to what the user is inputting
 	const updateParams = ['email', 'first_name', 'last_name']
 	for(var i = 0; i < updateParams.length; i++) {
@@ -98,7 +96,7 @@ router.put('/:id', function(req, res) {
 			return res.status(200).json(coach)
 		})
 		.catch(function(err) {
-			return res.status(500).json(err)
+			return next(err)
 		})
 })
 

--- a/api/routes/playerRouter.js
+++ b/api/routes/playerRouter.js
@@ -12,19 +12,18 @@ const PlayerStat = require('../models/PlayerStat');
 router.use(bodyParser.urlencoded({extended: true}));
 router.use(jsonParser);
 
-router.get('/', function(req, res) {
+router.get('/', function(req, res, next) {
   Player
   .fetchAll()
   .then(function(players) {
     res.json(players);
   })
   .catch(function(err) {
-    console.error(err);
-    return res.status(500).json(err);
+    return next(err);
   });
 })
 
-router.get('/:id', function(req, res) {
+router.get('/:id', function(req, res, next) {
   Player
   .where({id: parseInt(req.params.id, 10)})
   .fetch({withRelated: ['teams']})
@@ -32,12 +31,11 @@ router.get('/:id', function(req, res) {
     res.json(players);
   })
   .catch(function(err) {
-    console.error(err);
-    return res.status(500).json(err);
+    return next(err);
   });
 })
 
-router.get('/:id/stats', function(req, res) {
+router.get('/:id/stats', function(req, res, next) {
   Player
   .where({id: req.params.id})
   .fetch({withRelated: ['stats']})
@@ -45,13 +43,12 @@ router.get('/:id/stats', function(req, res) {
     res.json(stats);
   })
   .catch(function(err) {
-    console.error(err);
-    return res.status(500).json(err);
+    return next(err);
   });
 })
 
 // update player
-router.put('/:id', function(req, res) {
+router.put('/:id', function(req, res, next) {
 	// check to see if the proper params is equal to what the user is inputting
 	const updateParams = ['email', 'first_name', 'last_name', 'position'];
 	for(var i = 0; i < updateParams.length; i++) {
@@ -78,12 +75,12 @@ router.put('/:id', function(req, res) {
 			return res.status(200).json(player);
 		})
 		.catch(function(err) {
-			return res.status(500).json(err);
+			return next(err);
 		});
 });
 
 // update a stat tied to a player
- router.put('/:player_id/stats/:stat_catalog_id', function(req, res) {
+ router.put('/:player_id/stats/:stat_catalog_id', function(req, res, next) {
    const postParams = ['how_many'];
    for (var i = 0; i < postParams.length; i++) {
      const confirmPutParams = postParams[i];
@@ -109,12 +106,12 @@ router.put('/:id', function(req, res) {
      return res.status(200).json(player);
    })
    .catch(function(err) {
-     return res.status(500).json(err);
+     return next(err);
    })
  })
 
 // post new player
-router.post('/', function(req, res) {
+router.post('/', function(req, res, next) {
 	const postParams = ['email', 'first_name', 'last_name', 'position'];
 	for (var i = 0; i < postParams.length; i++) {
 		const confirmPostParams = postParams[i];
@@ -137,12 +134,12 @@ router.post('/', function(req, res) {
 			return res.status(200).json(player);
 		})
 		.catch(function(err) {
-			return res.status(500).json(err);
+			return next(err);
 		});
 });
 
 // post a new stat for a player
- router.post('/:player_id/stats/:stat_catalog_id', function(req, res) {
+ router.post('/:player_id/stats/:stat_catalog_id', function(req, res, next) {
    const postParams = ['how_many'];
    for (var i = 0; i < postParams.length; i++) {
      const confirmPostParams = postParams[i];
@@ -164,12 +161,12 @@ router.post('/', function(req, res) {
     return res.status(200).json(stat);
    })
    .catch(function(err) {
-     return res.status(500).json(err);
+     return next(err);
    })
  })
 
 
- router.delete('/:id', function(req, res) {
+ router.delete('/:id', function(req, res, next) {
    const deleteParams = ['id']
   for(var i = 0; i < deleteParams.length; i++) {
     const wrongId = deleteParams[i];
@@ -195,7 +192,7 @@ router.post('/', function(req, res) {
       });
   })
   .catch(function(err) {
-    return res.status(500).json(err);
+    return next(err);
   });
 })
 

--- a/api/routes/sessionRouter.js
+++ b/api/routes/sessionRouter.js
@@ -15,7 +15,7 @@ router.use(jsonParser);
 /*
  * Login and create a new session
  */
-router.post('/login', function(req, res){
+router.post('/login', function(req, res, next){
         let coachData;
         Coach
                 .where({
@@ -41,7 +41,7 @@ router.post('/login', function(req, res){
                         }
                 })
                 .catch(function(err){
-                        res.status(500).json(err);
+                        return next(err);
                 });
 });
 

--- a/api/routes/teamRouter.js
+++ b/api/routes/teamRouter.js
@@ -29,7 +29,7 @@ router.get('/:id', function(req, res) {
                });
 });
 
-router.put('/:id', function(req, res) {
+router.put('/:id', function(req, res, next) {
 	// check to see if the proper params is equal to what the user is inputting
 	const updateParams = ['name', 'city', 'state'];
 	for(var i = 0; i < updateParams.length; i++) {
@@ -56,11 +56,11 @@ router.put('/:id', function(req, res) {
 			return res.status(200).json(team);
 		})
 		.catch(function(err) {
-			return res.status(500).json(err);
+			return next(err);
 		});
 });
 
-router.post('/', function(req, res) {
+router.post('/', function(req, res, next) {
         const postParams = ['name', 'city', 'state', 'coachId'];
         for (var i = 0; i < postParams.length; i++) {
                 const confirmPostParams = postParams[i];
@@ -100,11 +100,11 @@ router.post('/', function(req, res) {
                                 });
                 })
                 .catch(function(err) {
-                        return res.status(500).json(err);
+                        return next(err);
                 });
 });
 
-router.post('/:id/player', function(req, res) {
+router.post('/:id/player', function(req, res, next) {
   const postParams = ['email', 'first_name', 'last_name', 'position']
   for (var i = 0; i < postParams.length; i++) {
     const confirmPostParams = postParams[i];
@@ -128,7 +128,7 @@ router.post('/:id/player', function(req, res) {
     return res.status(200).json(player)
   })
   .catch(function(err) {
-    return res.status(500).json(err)
+    return next(err)
   })
 })
 

--- a/server.js
+++ b/server.js
@@ -60,6 +60,12 @@ app.get('*', (req, res) => {
         res.sendFile(path.join(__dirname, 'build', 'index.html'));
 });
 
+// Error-handling middleware
+app.use((err, req, res, next) => {
+        console.error(err);
+        res.status(500).json({ error: 'Internal server error' });
+});
+
 let server;
 
 function runServer() {


### PR DESCRIPTION
## Summary
- add centralized error middleware for generic 500 responses
- route errors through `next(err)` instead of sending raw details

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden when fetching bulma)*
- `npm run lint` *(fails: ESLint couldn't find plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_68943b2ebc7c8328a4f7f207abd2daed